### PR TITLE
Only query wins and losses for ranked matches

### DIFF
--- a/cbsapi/api_blueprint.py
+++ b/cbsapi/api_blueprint.py
@@ -175,8 +175,8 @@ def player(name):
         if 'games' in filters:
             cursor.execute("""
             SELECT 
-                CAST(SUM(gps.win=1) AS UNSIGNED)    AS won,
-                CAST(SUM(gps.win=0) AS UNSIGNED)    AS lost
+                COALESCE(CAST(SUM(gps.win=1) AS UNSIGNED), 0)    AS won,
+                COALESCE(CAST(SUM(gps.win=0) AS UNSIGNED), 0)    AS lost
             FROM game_player_stats gps
             INNER JOIN game_stats gs
             ON (

--- a/cbsapi/api_blueprint.py
+++ b/cbsapi/api_blueprint.py
@@ -179,7 +179,13 @@ def player(name):
                 CAST(SUM(gps.win=0) AS UNSIGNED)    AS lost
             FROM game_player_stats gps
             INNER JOIN game_stats gs
-            ON ((gps.profile_id = gs.white_profile_id OR gps.profile_id = gs.black_profile_id) AND gps.game_id = gs.id)
+            ON (
+                (
+                    gps.profile_id = gs.white_profile_id 
+                    OR gps.profile_id = gs.black_profile_id
+                ) 
+                AND gps.game_id = gs.id
+            )
             WHERE gps.profile_id = %s
             AND gs.game_type = 'MP_RANKED'
             """, user_id)

--- a/cbsapi/api_blueprint.py
+++ b/cbsapi/api_blueprint.py
@@ -179,7 +179,7 @@ def player(name):
                 CAST(SUM(gps.win=0) AS UNSIGNED)    AS lost
             FROM game_player_stats gps
             INNER JOIN game_stats gs
-            ON gps.game_id = gs.id
+            ON ((gps.profile_id = gs.white_profile_id OR gps.profile_id = gs.black_profile_id) AND gps.game_id = gs.id)
             WHERE gps.profile_id = %s
             AND gs.game_type = 'MP_RANKED'
             """, user_id)

--- a/cbsapi/api_blueprint.py
+++ b/cbsapi/api_blueprint.py
@@ -175,10 +175,13 @@ def player(name):
         if 'games' in filters:
             cursor.execute("""
             SELECT 
-                CAST(SUM(win=1) AS UNSIGNED)    AS won,
-                CAST(SUM(win=0) AS UNSIGNED)    AS lost
-            FROM game_player_stats
-            WHERE profile_id = %s
+                CAST(SUM(gps.win=1) AS UNSIGNED)    AS won,
+                CAST(SUM(gps.win=0) AS UNSIGNED)    AS lost
+            FROM game_player_stats gps
+            INNER JOIN game_stats gs
+            ON gps.game_id = gs.id
+            WHERE gps.profile_id = %s
+            AND gs.game_type = 'MP_RANKED'
             """, user_id)
             result['games'] = cursor.fetchone()
 


### PR DESCRIPTION
Use only games with MP_RANKED game type for wins and losses calculation.

Not tested yet, as I haven't set a dev environment up and can't see example data in a table.